### PR TITLE
feat: add conditionalPut test case

### DIFF
--- a/coordinator/internal/config/config.go
+++ b/coordinator/internal/config/config.go
@@ -38,4 +38,5 @@ const (
 	TestCaseTypeStreamingSequence        = "streamingSequence"
 	TestCaseTypeMetadataWithEphemeral    = "metadataWithEphemeral"
 	TestCaseTypeMetadataWithNotification = "metadataWithNotification"
+	TestCaseTypeConditionalPut           = "conditionalPut"
 )

--- a/coordinator/internal/proto/okk.pb.go
+++ b/coordinator/internal/proto/okk.pb.go
@@ -217,14 +217,15 @@ func (*OperationSessionRestart) Descriptor() ([]byte, []int) {
 }
 
 type OperationPut struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Key              string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Value            []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
-	Ephemeral        bool                   `protobuf:"varint,3,opt,name=ephemeral,proto3" json:"ephemeral,omitempty"`
-	PartitionKey     *string                `protobuf:"bytes,4,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
-	SequenceKeyDelta []uint64               `protobuf:"varint,5,rep,packed,name=sequence_key_delta,json=sequenceKeyDelta,proto3" json:"sequence_key_delta,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Key               string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value             []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Ephemeral         bool                   `protobuf:"varint,3,opt,name=ephemeral,proto3" json:"ephemeral,omitempty"`
+	PartitionKey      *string                `protobuf:"bytes,4,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
+	SequenceKeyDelta  []uint64               `protobuf:"varint,5,rep,packed,name=sequence_key_delta,json=sequenceKeyDelta,proto3" json:"sequence_key_delta,omitempty"`
+	ExpectedVersionId *int64                 `protobuf:"varint,6,opt,name=expected_version_id,json=expectedVersionId,proto3,oneof" json:"expected_version_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *OperationPut) Reset() {
@@ -290,6 +291,13 @@ func (x *OperationPut) GetSequenceKeyDelta() []uint64 {
 		return x.SequenceKeyDelta
 	}
 	return nil
+}
+
+func (x *OperationPut) GetExpectedVersionId() int64 {
+	if x != nil && x.ExpectedVersionId != nil {
+		return *x.ExpectedVersionId
+	}
+	return 0
 }
 
 type OperationGet struct {
@@ -911,14 +919,15 @@ func (x *Record) GetValue() []byte {
 }
 
 type Assertion struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	EventuallyEmpty *bool                  `protobuf:"varint,1,opt,name=eventually_empty,json=eventuallyEmpty,proto3,oneof" json:"eventually_empty,omitempty"`
-	EmptyRecords    *bool                  `protobuf:"varint,2,opt,name=empty_records,json=emptyRecords,proto3,oneof" json:"empty_records,omitempty"`
-	PartitionKey    *string                `protobuf:"bytes,3,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
-	Records         []*Record              `protobuf:"bytes,4,rep,name=records,proto3" json:"records,omitempty"`
-	Notification    *Notification          `protobuf:"bytes,5,opt,name=notification,proto3,oneof" json:"notification,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	EventuallyEmpty       *bool                  `protobuf:"varint,1,opt,name=eventually_empty,json=eventuallyEmpty,proto3,oneof" json:"eventually_empty,omitempty"`
+	EmptyRecords          *bool                  `protobuf:"varint,2,opt,name=empty_records,json=emptyRecords,proto3,oneof" json:"empty_records,omitempty"`
+	PartitionKey          *string                `protobuf:"bytes,3,opt,name=partition_key,json=partitionKey,proto3,oneof" json:"partition_key,omitempty"`
+	Records               []*Record              `protobuf:"bytes,4,rep,name=records,proto3" json:"records,omitempty"`
+	Notification          *Notification          `protobuf:"bytes,5,opt,name=notification,proto3,oneof" json:"notification,omitempty"`
+	ExpectVersionConflict *bool                  `protobuf:"varint,6,opt,name=expect_version_conflict,json=expectVersionConflict,proto3,oneof" json:"expect_version_conflict,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *Assertion) Reset() {
@@ -986,6 +995,13 @@ func (x *Assertion) GetNotification() *Notification {
 	return nil
 }
 
+func (x *Assertion) GetExpectVersionConflict() bool {
+	if x != nil && x.ExpectVersionConflict != nil {
+		return *x.ExpectVersionConflict
+	}
+	return false
+}
+
 type ExecuteCommand struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Testcase      string                 `protobuf:"bytes,1,opt,name=testcase,proto3" json:"testcase,omitempty"`
@@ -1050,6 +1066,7 @@ type ExecuteResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Status        Status                 `protobuf:"varint,1,opt,name=status,proto3,enum=io.oxia.okk.proto.v1.Status" json:"status,omitempty"`
 	StatusInfo    string                 `protobuf:"bytes,2,opt,name=status_info,json=statusInfo,proto3" json:"status_info,omitempty"`
+	VersionId     *int64                 `protobuf:"varint,3,opt,name=version_id,json=versionId,proto3,oneof" json:"version_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1098,19 +1115,28 @@ func (x *ExecuteResponse) GetStatusInfo() string {
 	return ""
 }
 
+func (x *ExecuteResponse) GetVersionId() int64 {
+	if x != nil && x.VersionId != nil {
+		return *x.VersionId
+	}
+	return 0
+}
+
 var File_okk_proto protoreflect.FileDescriptor
 
 const file_okk_proto_rawDesc = "" +
 	"\n" +
 	"\tokk.proto\x12\x14io.oxia.okk.proto.v1\"\x19\n" +
-	"\x17OperationSessionRestart\"\xbe\x01\n" +
+	"\x17OperationSessionRestart\"\x8b\x02\n" +
 	"\fOperationPut\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value\x12\x1c\n" +
 	"\tephemeral\x18\x03 \x01(\bR\tephemeral\x12(\n" +
 	"\rpartition_key\x18\x04 \x01(\tH\x00R\fpartitionKey\x88\x01\x01\x12,\n" +
-	"\x12sequence_key_delta\x18\x05 \x03(\x04R\x10sequenceKeyDeltaB\x10\n" +
-	"\x0e_partition_key\"r\n" +
+	"\x12sequence_key_delta\x18\x05 \x03(\x04R\x10sequenceKeyDelta\x123\n" +
+	"\x13expected_version_id\x18\x06 \x01(\x03H\x01R\x11expectedVersionId\x88\x01\x01B\x10\n" +
+	"\x0e_partition_keyB\x16\n" +
+	"\x14_expected_version_id\"r\n" +
 	"\fOperationGet\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12P\n" +
 	"\x0fcomparison_type\x18\x02 \x01(\x0e2'.io.oxia.okk.proto.v1.KeyComparisonTypeR\x0ecomparisonType\"E\n" +
@@ -1159,25 +1185,30 @@ const file_okk_proto_rawDesc = "" +
 	"\b_key_end\"0\n" +
 	"\x06Record\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value\"\xde\x02\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\xb7\x03\n" +
 	"\tAssertion\x12.\n" +
 	"\x10eventually_empty\x18\x01 \x01(\bH\x00R\x0feventuallyEmpty\x88\x01\x01\x12(\n" +
 	"\rempty_records\x18\x02 \x01(\bH\x01R\femptyRecords\x88\x01\x01\x12(\n" +
 	"\rpartition_key\x18\x03 \x01(\tH\x02R\fpartitionKey\x88\x01\x01\x126\n" +
 	"\arecords\x18\x04 \x03(\v2\x1c.io.oxia.okk.proto.v1.RecordR\arecords\x12K\n" +
-	"\fnotification\x18\x05 \x01(\v2\".io.oxia.okk.proto.v1.NotificationH\x03R\fnotification\x88\x01\x01B\x13\n" +
+	"\fnotification\x18\x05 \x01(\v2\".io.oxia.okk.proto.v1.NotificationH\x03R\fnotification\x88\x01\x01\x12;\n" +
+	"\x17expect_version_conflict\x18\x06 \x01(\bH\x04R\x15expectVersionConflict\x88\x01\x01B\x13\n" +
 	"\x11_eventually_emptyB\x10\n" +
 	"\x0e_empty_recordsB\x10\n" +
 	"\x0e_partition_keyB\x0f\n" +
-	"\r_notification\"\x89\x01\n" +
+	"\r_notificationB\x1a\n" +
+	"\x18_expect_version_conflict\"\x89\x01\n" +
 	"\x0eExecuteCommand\x12\x1a\n" +
 	"\btestcase\x18\x01 \x01(\tR\btestcase\x12=\n" +
 	"\toperation\x18\x02 \x01(\v2\x1f.io.oxia.okk.proto.v1.OperationR\toperation\x12\x1c\n" +
-	"\tnamespace\x18\x03 \x01(\tR\tnamespace\"h\n" +
+	"\tnamespace\x18\x03 \x01(\tR\tnamespace\"\x9b\x01\n" +
 	"\x0fExecuteResponse\x124\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x1c.io.oxia.okk.proto.v1.StatusR\x06status\x12\x1f\n" +
 	"\vstatus_info\x18\x02 \x01(\tR\n" +
-	"statusInfo*M\n" +
+	"statusInfo\x12\"\n" +
+	"\n" +
+	"version_id\x18\x03 \x01(\x03H\x00R\tversionId\x88\x01\x01B\r\n" +
+	"\v_version_id*M\n" +
 	"\x11KeyComparisonType\x12\t\n" +
 	"\x05EQUAL\x10\x00\x12\t\n" +
 	"\x05FLOOR\x10\x01\x12\v\n" +
@@ -1274,6 +1305,7 @@ func file_okk_proto_init() {
 	file_okk_proto_msgTypes[8].OneofWrappers = []any{}
 	file_okk_proto_msgTypes[9].OneofWrappers = []any{}
 	file_okk_proto_msgTypes[11].OneofWrappers = []any{}
+	file_okk_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/coordinator/internal/proto/okk_vtproto.pb.go
+++ b/coordinator/internal/proto/okk_vtproto.pb.go
@@ -57,6 +57,10 @@ func (m *OperationPut) CloneVT() *OperationPut {
 		copy(tmpContainer, rhs)
 		r.SequenceKeyDelta = tmpContainer
 	}
+	if rhs := m.ExpectedVersionId; rhs != nil {
+		tmpVal := *rhs
+		r.ExpectedVersionId = &tmpVal
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -343,6 +347,10 @@ func (m *Assertion) CloneVT() *Assertion {
 		}
 		r.Records = tmpContainer
 	}
+	if rhs := m.ExpectVersionConflict; rhs != nil {
+		tmpVal := *rhs
+		r.ExpectVersionConflict = &tmpVal
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -380,6 +388,10 @@ func (m *ExecuteResponse) CloneVT() *ExecuteResponse {
 	r := new(ExecuteResponse)
 	r.Status = m.Status
 	r.StatusInfo = m.StatusInfo
+	if rhs := m.VersionId; rhs != nil {
+		tmpVal := *rhs
+		r.VersionId = &tmpVal
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -433,6 +445,9 @@ func (this *OperationPut) EqualVT(that *OperationPut) bool {
 		if vx != vy {
 			return false
 		}
+	}
+	if p, q := this.ExpectedVersionId, that.ExpectedVersionId; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -873,6 +888,9 @@ func (this *Assertion) EqualVT(that *Assertion) bool {
 	if !this.Notification.EqualVT(that.Notification) {
 		return false
 	}
+	if p, q := this.ExpectVersionConflict, that.ExpectVersionConflict; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -918,6 +936,9 @@ func (this *ExecuteResponse) EqualVT(that *ExecuteResponse) bool {
 		return false
 	}
 	if this.StatusInfo != that.StatusInfo {
+		return false
+	}
+	if p, q := this.VersionId, that.VersionId; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -992,6 +1013,11 @@ func (m *OperationPut) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ExpectedVersionId != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.ExpectedVersionId))
+		i--
+		dAtA[i] = 0x30
 	}
 	if len(m.SequenceKeyDelta) > 0 {
 		var pksize2 int
@@ -1669,6 +1695,16 @@ func (m *Assertion) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.ExpectVersionConflict != nil {
+		i--
+		if *m.ExpectVersionConflict {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
+	}
 	if m.Notification != nil {
 		size, err := m.Notification.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -1808,6 +1844,11 @@ func (m *ExecuteResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.VersionId != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.VersionId))
+		i--
+		dAtA[i] = 0x18
+	}
 	if len(m.StatusInfo) > 0 {
 		i -= len(m.StatusInfo)
 		copy(dAtA[i:], m.StatusInfo)
@@ -1860,6 +1901,9 @@ func (m *OperationPut) SizeVT() (n int) {
 			l += protohelpers.SizeOfVarint(uint64(e))
 		}
 		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
+	if m.ExpectedVersionId != nil {
+		n += 1 + protohelpers.SizeOfVarint(uint64(*m.ExpectedVersionId))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2146,6 +2190,9 @@ func (m *Assertion) SizeVT() (n int) {
 		l = m.Notification.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.ExpectVersionConflict != nil {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2184,6 +2231,9 @@ func (m *ExecuteResponse) SizeVT() (n int) {
 	l = len(m.StatusInfo)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.VersionId != nil {
+		n += 1 + protohelpers.SizeOfVarint(uint64(*m.VersionId))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2464,6 +2514,26 @@ func (m *OperationPut) UnmarshalVT(dAtA []byte) error {
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field SequenceKeyDelta", wireType)
 			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectedVersionId", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ExpectedVersionId = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -4017,6 +4087,27 @@ func (m *Assertion) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectVersionConflict", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			b := bool(v != 0)
+			m.ExpectVersionConflict = &b
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -4270,6 +4361,26 @@ func (m *ExecuteResponse) UnmarshalVT(dAtA []byte) error {
 			}
 			m.StatusInfo = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VersionId", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.VersionId = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -4572,6 +4683,26 @@ func (m *OperationPut) UnmarshalVTUnsafe(dAtA []byte) error {
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field SequenceKeyDelta", wireType)
 			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectedVersionId", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ExpectedVersionId = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -6174,6 +6305,27 @@ func (m *Assertion) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectVersionConflict", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			b := bool(v != 0)
+			m.ExpectVersionConflict = &b
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -6439,6 +6591,26 @@ func (m *ExecuteResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.StatusInfo = stringValue
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VersionId", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.VersionId = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/coordinator/internal/task/generator/conditional_put.go
+++ b/coordinator/internal/task/generator/conditional_put.go
@@ -1,0 +1,372 @@
+package generator
+
+import (
+	"context"
+	"log/slog"
+	"math/rand/v2"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/oxia-io/okk/coordinator/internal/config"
+	"github.com/oxia-io/okk/coordinator/internal/proto"
+	"golang.org/x/time/rate"
+)
+
+var _ ResponseAwareGenerator = &conditionalPut{}
+
+type keyState struct {
+	versionId int64
+	value     string
+}
+
+type conditionalPut struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	name   string
+	logger *slog.Logger
+
+	duration  *time.Duration
+	rateLimit *rate.Limiter
+	startTime time.Time
+	keySpace  int64
+
+	needsCleanup bool
+	initialized  bool
+	sequence     int64
+
+	// Track version per key. Missing key means key doesn't exist in Oxia.
+	keys map[int64]*keyState
+
+	// pendingKey tracks which key the last operation targeted,
+	// so OnResponse can update the version cache.
+	pendingKeyIndex int64
+	pendingAction   int // 0=create, 1=update, 2=delete, 3=conflictCreate, 4=staleUpdate, 5=get
+	pendingValue    string
+}
+
+func (c *conditionalPut) Name() string {
+	return "conditional-put"
+}
+
+func (c *conditionalPut) OnResponse(resp *proto.ExecuteResponse) {
+	if resp.VersionId == nil {
+		return
+	}
+	vid := *resp.VersionId
+
+	switch c.pendingAction {
+	case 0: // create
+		c.keys[c.pendingKeyIndex] = &keyState{versionId: vid, value: c.pendingValue}
+	case 1: // update
+		if ks, ok := c.keys[c.pendingKeyIndex]; ok {
+			ks.versionId = vid
+			ks.value = c.pendingValue
+		}
+	case 2: // delete
+		delete(c.keys, c.pendingKeyIndex)
+	// 3 (conflictCreate) and 4 (staleUpdate) are expected-failure ops;
+	// the state doesn't change.
+	}
+}
+
+func (c *conditionalPut) Next() (*proto.Operation, bool) {
+	if c.needsCleanup {
+		c.needsCleanup = false
+		c.logger.Info("Cleaning up stale data from previous run", "prefix", c.name)
+		return &proto.Operation{
+			Operation: &proto.Operation_DeleteRange{
+				DeleteRange: &proto.OperationDeleteRange{
+					KeyStart: c.name,
+					KeyEnd:   c.name + "~",
+				},
+			},
+		}, true
+	}
+
+	if c.duration != nil && time.Since(c.startTime) > *c.duration {
+		c.logger.Info("Finished conditional-put generator", "name", c.name)
+		return nil, false
+	}
+	if err := c.rateLimit.Wait(c.ctx); err != nil {
+		return nil, false
+	}
+
+	if !c.initialized {
+		return c.processInitStage()
+	}
+
+	return c.processValidation()
+}
+
+func (c *conditionalPut) processInitStage() (*proto.Operation, bool) {
+	idx := c.sequence
+	c.sequence++
+
+	uid := uuid.New().String()
+	c.pendingKeyIndex = idx
+	c.pendingAction = 0
+	c.pendingValue = uid
+
+	versionId := int64(-1) // must not exist
+	if idx >= c.keySpace {
+		c.initialized = true
+	}
+	return &proto.Operation{
+		Operation: &proto.Operation_Put{
+			Put: &proto.OperationPut{
+				Key:               makeKey(c.name, idx),
+				Value:             makeValue(c.name, uid),
+				ExpectedVersionId: &versionId,
+			},
+		},
+	}, true
+}
+
+func (c *conditionalPut) processValidation() (*proto.Operation, bool) {
+	// Weighted random action selection:
+	// 25% conditional update, 25% get, 15% conflict create, 15% stale update, 10% delete+recreate, 10% unconditional put
+	roll := rand.IntN(100)
+
+	switch {
+	case roll < 25:
+		return c.genConditionalUpdate()
+	case roll < 50:
+		return c.genGet()
+	case roll < 65:
+		return c.genConflictCreate()
+	case roll < 80:
+		return c.genStaleUpdate()
+	case roll < 90:
+		return c.genDeleteAndRecreate()
+	default:
+		return c.genUnconditionalPut()
+	}
+}
+
+// genConditionalUpdate: put with correct expected_version_id on an existing key.
+func (c *conditionalPut) genConditionalUpdate() (*proto.Operation, bool) {
+	idx, ks := c.pickExistingKey()
+	if ks == nil {
+		// No existing keys, fall back to get
+		return c.genGet()
+	}
+
+	uid := uuid.New().String()
+	c.pendingKeyIndex = idx
+	c.pendingAction = 1
+	c.pendingValue = uid
+
+	vid := ks.versionId
+	return &proto.Operation{
+		Assertion: &proto.Assertion{
+			Records: []*proto.Record{
+				{
+					Key:   makeKey(c.name, idx),
+					Value: makeValue(c.name, uid),
+				},
+			},
+		},
+		Operation: &proto.Operation_Put{
+			Put: &proto.OperationPut{
+				Key:               makeKey(c.name, idx),
+				Value:             makeValue(c.name, uid),
+				ExpectedVersionId: &vid,
+			},
+		},
+	}, true
+}
+
+// genGet: get a key and assert its value.
+func (c *conditionalPut) genGet() (*proto.Operation, bool) {
+	idx := rand.Int64N(c.keySpace)
+	c.pendingKeyIndex = idx
+	c.pendingAction = 5
+
+	ks, exists := c.keys[idx]
+	emptyRecord := !exists
+
+	assertion := &proto.Assertion{
+		EmptyRecords: &emptyRecord,
+	}
+	if exists {
+		assertion.Records = []*proto.Record{
+			{
+				Key:   makeKey(c.name, idx),
+				Value: makeValue(c.name, ks.value),
+			},
+		}
+	}
+	return &proto.Operation{
+		Assertion: assertion,
+		Operation: &proto.Operation_Get{
+			Get: &proto.OperationGet{
+				Key:            makeKey(c.name, idx),
+				ComparisonType: proto.KeyComparisonType_EQUAL,
+			},
+		},
+	}, true
+}
+
+// genConflictCreate: put with expected_version_id=-1 on a key that exists.
+// This should fail with version conflict.
+func (c *conditionalPut) genConflictCreate() (*proto.Operation, bool) {
+	idx, ks := c.pickExistingKey()
+	if ks == nil {
+		return c.genGet()
+	}
+
+	c.pendingKeyIndex = idx
+	c.pendingAction = 3
+
+	uid := uuid.New().String()
+	versionId := int64(-1)
+	expectConflict := true
+	return &proto.Operation{
+		Assertion: &proto.Assertion{
+			ExpectVersionConflict: &expectConflict,
+		},
+		Operation: &proto.Operation_Put{
+			Put: &proto.OperationPut{
+				Key:               makeKey(c.name, idx),
+				Value:             makeValue(c.name, uid),
+				ExpectedVersionId: &versionId,
+			},
+		},
+	}, true
+}
+
+// genStaleUpdate: put with a wrong version on an existing key.
+func (c *conditionalPut) genStaleUpdate() (*proto.Operation, bool) {
+	idx, ks := c.pickExistingKey()
+	if ks == nil {
+		return c.genGet()
+	}
+
+	c.pendingKeyIndex = idx
+	c.pendingAction = 4
+
+	uid := uuid.New().String()
+	// Use a stale version (current version - 1, or 0 if version is 0)
+	staleVersion := ks.versionId - 1
+	if staleVersion < 0 {
+		staleVersion = ks.versionId + 999999
+	}
+	expectConflict := true
+	return &proto.Operation{
+		Assertion: &proto.Assertion{
+			ExpectVersionConflict: &expectConflict,
+		},
+		Operation: &proto.Operation_Put{
+			Put: &proto.OperationPut{
+				Key:               makeKey(c.name, idx),
+				Value:             makeValue(c.name, uid),
+				ExpectedVersionId: &staleVersion,
+			},
+		},
+	}, true
+}
+
+// genDeleteAndRecreate: delete a key, then it will be recreated next cycle.
+func (c *conditionalPut) genDeleteAndRecreate() (*proto.Operation, bool) {
+	idx, ks := c.pickExistingKey()
+	if ks == nil {
+		return c.genGet()
+	}
+
+	c.pendingKeyIndex = idx
+	c.pendingAction = 2
+
+	delete(c.keys, idx)
+	return &proto.Operation{
+		Operation: &proto.Operation_Delete{
+			Delete: &proto.OperationDelete{
+				Key: makeKey(c.name, idx),
+			},
+		},
+	}, true
+}
+
+// genUnconditionalPut: conditional create on a deleted key to recreate it.
+func (c *conditionalPut) genUnconditionalPut() (*proto.Operation, bool) {
+	idx := c.pickDeletedKey()
+	if idx < 0 {
+		// No deleted keys available, fall back to get
+		return c.genGet()
+	}
+
+	uid := uuid.New().String()
+	c.pendingKeyIndex = idx
+	c.pendingAction = 0
+	c.pendingValue = uid
+
+	versionId := int64(-1) // must not exist
+	return &proto.Operation{
+		Operation: &proto.Operation_Put{
+			Put: &proto.OperationPut{
+				Key:               makeKey(c.name, idx),
+				Value:             makeValue(c.name, uid),
+				ExpectedVersionId: &versionId,
+			},
+		},
+	}, true
+}
+
+func (c *conditionalPut) pickExistingKey() (int64, *keyState) {
+	// Try random keys up to 10 times to find an existing one
+	for range 10 {
+		idx := rand.Int64N(c.keySpace)
+		if ks, ok := c.keys[idx]; ok {
+			return idx, ks
+		}
+	}
+	// Linear scan as fallback
+	for idx, ks := range c.keys {
+		return idx, ks
+	}
+	return 0, nil
+}
+
+func (c *conditionalPut) pickDeletedKey() int64 {
+	for range 20 {
+		idx := rand.Int64N(c.keySpace)
+		if _, ok := c.keys[idx]; !ok {
+			return idx
+		}
+	}
+	// All keys exist
+	return -1
+}
+
+func NewConditionalPut(ctx context.Context, tc *config.TestCaseConfig) Generator {
+	currentCtx, cancel := context.WithCancel(ctx)
+	logger := slog.With("generator", "conditional-put", "name", tc.Name)
+	logger.Info("Starting conditional-put generator")
+
+	keySpace := int64(100)
+	if properties := tc.Properties; properties != nil {
+		if num, exist := properties[propertiesKeyKeySpace]; exist {
+			intVal, err := strconv.ParseInt(num, 10, 64)
+			if err != nil {
+				logger.Error("Failed to parse keySpace property, using default 100", "value", num, "error", err)
+			} else {
+				keySpace = intVal
+			}
+		}
+	}
+
+	opRate := tc.GetOpRate()
+	return &conditionalPut{
+		ctx:          currentCtx,
+		cancel:       cancel,
+		name:         tc.Name,
+		logger:       logger,
+		duration:     tc.GetDuration(),
+		rateLimit:    rate.NewLimiter(rate.Limit(opRate), opRate),
+		startTime:    time.Now(),
+		keySpace:     keySpace,
+		needsCleanup: true,
+		keys:         make(map[int64]*keyState),
+	}
+}
+

--- a/coordinator/internal/task/generator/conditional_put.go
+++ b/coordinator/internal/task/generator/conditional_put.go
@@ -63,10 +63,8 @@ func (c *conditionalPut) OnResponse(resp *proto.ExecuteResponse) {
 			ks.versionId = vid
 			ks.value = c.pendingValue
 		}
-	case 2: // delete
-		delete(c.keys, c.pendingKeyIndex)
-	// 3 (conflictCreate) and 4 (staleUpdate) are expected-failure ops;
-	// the state doesn't change.
+	// case 2 (delete): state already updated eagerly in genDeleteAndRecreate
+	// case 3,4 (conflict ops): state doesn't change
 	}
 }
 
@@ -109,7 +107,7 @@ func (c *conditionalPut) processInitStage() (*proto.Operation, bool) {
 	c.pendingValue = uid
 
 	versionId := int64(-1) // must not exist
-	if idx >= c.keySpace {
+	if c.sequence >= c.keySpace {
 		c.initialized = true
 	}
 	return &proto.Operation{

--- a/coordinator/internal/task/generator/generator.go
+++ b/coordinator/internal/task/generator/generator.go
@@ -7,3 +7,10 @@ type Generator interface {
 
 	Next() (*proto.Operation, bool)
 }
+
+// ResponseAwareGenerator is an optional interface for generators that need
+// feedback from operation responses (e.g., to track version IDs).
+type ResponseAwareGenerator interface {
+	Generator
+	OnResponse(*proto.ExecuteResponse)
+}

--- a/coordinator/internal/task/manager.go
+++ b/coordinator/internal/task/manager.go
@@ -115,6 +115,8 @@ func (m *Manager) createGenerator(tc *config.TestCaseConfig) generator.Generator
 		return generator.NewMetadataNotificationGenerator(m.ctx, tc)
 	case config.TestCaseTypeMetadataWithEphemeral:
 		return generator.NewMetadataEphemeralGenerator(m.ctx, tc)
+	case config.TestCaseTypeConditionalPut:
+		return generator.NewConditionalPut(m.ctx, tc)
 	default:
 		return nil
 	}

--- a/coordinator/internal/task/task.go
+++ b/coordinator/internal/task/task.go
@@ -128,6 +128,9 @@ func (t *task) run() error {
 					if operation.Assertion != nil {
 						t.assertionsPassed.Add(1)
 					}
+					if rag, ok := t.generator.(generator.ResponseAwareGenerator); ok {
+						rag.OnResponse(response)
+					}
 					t.syncStatus()
 					return nil
 				case proto.Status_RetryableFailure:

--- a/coordinator/proto/okk.proto
+++ b/coordinator/proto/okk.proto
@@ -15,6 +15,7 @@ message OperationPut {
   bool ephemeral = 3;
   optional string partition_key = 4;
   repeated uint64 sequence_key_delta = 5;
+  optional int64 expected_version_id = 6;
 }
 
 enum KeyComparisonType {
@@ -92,6 +93,7 @@ message Assertion {
   optional string partition_key = 3;
   repeated Record records = 4;
   optional Notification notification = 5;
+  optional bool expect_version_conflict = 6;
 }
 
 message ExecuteCommand {
@@ -110,6 +112,7 @@ enum Status {
 message ExecuteResponse {
   Status status = 1;
   string status_info = 2;
+  optional int64 version_id = 3;
 }
 
 service Okk {

--- a/worker/jvm/engine-oxia/src/main/java/io/github/oxia/worker/engine/oxia/OxiaEngine.java
+++ b/worker/jvm/engine-oxia/src/main/java/io/github/oxia/worker/engine/oxia/OxiaEngine.java
@@ -125,7 +125,51 @@ public class OxiaEngine implements Engine {
         if (put.getEphemeral()) {
             optionSet.add(OptionEphemeral.AsEphemeralRecord);
         }
-        final PutResult result = oxiaClient.put(put.getKey(), put.getValue().toByteArray(), optionSet).join();
+        if (put.hasExpectedVersionId()) {
+            long expectedVersion = put.getExpectedVersionId();
+            if (expectedVersion == -1) {
+                optionSet.add(PutOption.IfRecordDoesNotExist);
+            } else {
+                optionSet.add(PutOption.IfVersionIdEquals(expectedVersion));
+            }
+        }
+
+        // Check if this operation expects a version conflict
+        boolean expectConflict = operation.hasAssertion()
+                && operation.getAssertion().hasExpectVersionConflict()
+                && operation.getAssertion().getExpectVersionConflict();
+
+        final PutResult result;
+        try {
+            result = oxiaClient.put(put.getKey(), put.getValue().toByteArray(), optionSet).join();
+        } catch (Exception ex) {
+            Throwable cause = ex;
+            while (cause.getCause() != null) {
+                cause = cause.getCause();
+            }
+            if (expectConflict) {
+                log.info("[Put][{}] Expected version conflict occurred as expected: {}",
+                        operation.getSequence(), cause.getMessage());
+                return ExecuteResponse.newBuilder()
+                        .setStatus(Status.Ok)
+                        .build();
+            }
+            throw ex;
+        }
+
+        if (expectConflict) {
+            log.warn("[Put][{}] Expected version conflict but put succeeded", operation.getSequence());
+            return ExecuteResponse.newBuilder()
+                    .setStatus(Status.AssertionFailure)
+                    .setStatusInfo("expected version conflict but put succeeded")
+                    .build();
+        }
+
+        // Return version_id from successful put
+        var responseBuilder = ExecuteResponse.newBuilder().setStatus(Status.Ok);
+        if (result.version() != null) {
+            responseBuilder.setVersionId(result.version().versionId());
+        }
 
         if (operation.hasAssertion()) {
             final Assertion assertion = operation.getAssertion();
@@ -175,9 +219,7 @@ public class OxiaEngine implements Engine {
             }
         }
 
-        return ExecuteResponse.newBuilder()
-                .setStatus(Status.Ok)
-                .build();
+        return responseBuilder.build();
     }
 
     private ExecuteResponse processScan(Operation operation) {

--- a/worker/jvm/engine-oxia/src/main/java/io/github/oxia/worker/engine/oxia/OxiaEngine.java
+++ b/worker/jvm/engine-oxia/src/main/java/io/github/oxia/worker/engine/oxia/OxiaEngine.java
@@ -6,6 +6,8 @@ import io.oxia.client.api.GetResult;
 import io.oxia.client.api.Notification;
 import io.oxia.client.api.Notification;
 import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.client.api.exceptions.KeyAlreadyExistsException;
+import io.oxia.client.api.exceptions.UnexpectedVersionIdException;
 import io.oxia.client.api.PutResult;
 import io.oxia.client.api.options.GetOption;
 import io.oxia.client.api.options.PutOption;
@@ -147,7 +149,9 @@ public class OxiaEngine implements Engine {
             while (cause.getCause() != null) {
                 cause = cause.getCause();
             }
-            if (expectConflict) {
+            boolean isVersionConflict = cause instanceof KeyAlreadyExistsException
+                    || cause instanceof UnexpectedVersionIdException;
+            if (expectConflict && isVersionConflict) {
                 log.info("[Put][{}] Expected version conflict occurred as expected: {}",
                         operation.getSequence(), cause.getMessage());
                 return ExecuteResponse.newBuilder()


### PR DESCRIPTION
## Summary
- Adds a new `conditionalPut` test case type that exercises Oxia's version-based conditional put API (optimistic concurrency control)
- Extends proto with `expected_version_id` on puts, `expect_version_conflict` on assertions, and `version_id` on responses
- Worker handles conditional puts via `PutOption.IfRecordDoesNotExist` and `PutOption.IfVersionIdEquals`, with proper version conflict detection
- Generator tracks version IDs via a new `ResponseAwareGenerator` interface callback, testing conditional creates, updates, conflict detection, stale version rejection, and delete+recreate cycles

## Test plan
- [x] Coordinator compiles (`go build ./...`)
- [x] Worker compiles (`./gradlew build`)
- [x] Deployed to local kind cluster and verified: 227+ ops, 142+ assertions passed, 0 failures
- [x] Verified all operation types in worker logs: conditional updates, conflict creates (key already exists), stale updates (unexpected versionId), gets with value assertions, deletes
